### PR TITLE
Stopped form refresh in onUpdate (fixes #116)

### DIFF
--- a/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/imports/fileimport/ImportFilesPage.java
+++ b/budgeteer-web-interface/src/main/java/org/wickedsource/budgeteer/web/pages/imports/fileimport/ImportFilesPage.java
@@ -123,7 +123,6 @@ public class ImportFilesPage extends DialogPageWithBacklink {
             @Override
             protected void onUpdate(AjaxRequestTarget target) {
                 skippedImports = null;
-                target.add(form);
             }
         });
         importerChoice.setRequired(true);


### PR DESCRIPTION
The import form gets refreshed every time the import format changes. See issue #116 for more details.