### PR TITLE
updated spring boot version

### DIFF
--- a/budgeteer-web-interface/build.gradle
+++ b/budgeteer-web-interface/build.gradle
@@ -89,7 +89,7 @@ dependencies {
             [group: 'org.dbunit', name: 'dbunit', version: "${dbunit_version}"],
     )
 
-    testCompile "org.springframework.boot:spring-boot-starter-test" // version?
+    testCompile "org.springframework.boot:spring-boot-starter-test"
 
     providedCompile group: 'org.projectlombok', name: 'lombok', version: "${lombok_version}"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-spring_boot_version = 1.5.1.RELEASE
+spring_boot_version = 1.5.2.RELEASE
 springloaded_version = 1.2.5.RELEASE
 spring_version = 4.3.6.RELEASE
 #
@@ -32,7 +32,5 @@ mockito_version=2.7.5
 junit_version=4.12
 #
 lombok_version = 1.16.12
-#
-liquibase_core_version = 3.5.1
 #
 hibernate.version=5.0.2.Final


### PR DESCRIPTION
The new spring boot version fixes the Gradle deprecation:
```
budgeteer-web-interface:bootRepackage
ModuleDependency.getConfiguration() has been deprecated and is scheduled to be removed in Gradle 4.0. Use ModuleDependency.getTargetConfiguration() instead.
```